### PR TITLE
replace application_status route

### DIFF
--- a/back/src/routes/airtable.ts
+++ b/back/src/routes/airtable.ts
@@ -38,57 +38,26 @@ airtableRouter.post('/login', function(req, res, next) {
   });
 
 airtableRouter.post('/application_status', (req, res, next) => {
-    //console.log('what is this ' + JSON.stringify(req.body))
-    const passphrase = req.body.passphrase;
-    
-    let get_record_id = new Promise((resolve,reject) => {
-        let record_idx = null;
-        
-        base('Human Readable Passphrases').select({
-            maxRecords: 1,
-            view: "Grid view"
-        }).eachPage(function page(records, fetchNextPage){
-            records.forEach(function(record){
-                if(record.get('Passphrase') == passphrase){
-                    record_idx = record.get('FR Record ID')
-                    console.log("record id: " + record_idx)
-                }
-            })
-    
-            fetchNextPage();
-    
-        }, function done(err){
-            if(err) {console.log(err); return}
-            resolve(record_idx)
-        });
-        
-
-
-    })
-
-    get_record_id
-    .then((record_idx)=>{
-      
-        base('2021 Form Responses').select({filterByFormula: `{BRF 2021 Application Record ID} = '${record_idx}'`}).firstPage((err, records)=>{
-
-            if(err){
-                console.log("error: " + err);
-                res.sendStatus(404)
-                return;
-            }else if (records.length == 1){
-                console.log(records[0].fields['BRF Application Stage']);
-                console.log("what is this: " + JSON.stringify(records))
-                res.send(records[0].fields['BRF Application Stage']);  
-            }else{
-                console.log("error either too many records, or no record found")
-                res.sendStatus(404);
-            }
-             
-        })
-       
-    })
-     
-})
+    const fields = {
+      status: "",
+      description: "",
+    };
+    base('2021 Form Responses').select({
+      fields: ["Applicant First Name", "Applicant Last Name", "PWA Status", "PWA Status Description"],
+      filterByFormula: `AND({Applicant First Name} = '${req.body.firstName}', {Applicant Last Name} = '${req.body.lastName}')`
+    }).firstPage(function(err, records) {
+      if(err) { console.error(err); return; }
+      if(records.length > 1) { 
+        console.error("More than one record return from application status check"); 
+        res.sendStatus(404);
+        return; 
+      }
+      fields.status = records[0].fields['PWA Status'];
+      fields.description = records[0].fields['PWA Status Description'];
+      res.write(JSON.stringify(fields));
+      res.end();
+    });
+});
 
 airtableRouter.get("/isLoggedIn", function (req, res, next) {
   if (req.user) {


### PR DESCRIPTION
This is an update to the application_status route to include status and description in the response and check for name instead of human-readable passphrase.