### PR TITLE
change the route structure to allow for calling through https

### DIFF
--- a/frontend/src/util/config.ts
+++ b/frontend/src/util/config.ts
@@ -4,21 +4,23 @@ import dotenv from "dotenv"
  * above line is causing errors, needs to be resolved to use .env
  */
 //const server = process.env.EXTERNAL_IP;
-//const server = "localhost:5000";
-const server = '34.82.220.171';
+// const server = "http://localhost:5000";
+// const server = 'http://34.82.220.171';
+const server = 'http://appstatus.brownhope.org';
+// const server = 'https://appstatus.brownhope.org';
 export const routes = {
-  login: `http://${server}/api/airtable/login/`,
-  signup: `http://${server}/api/airtable/signup/`,
-  email: `http://${server}/api/airtable/email/`,
-  signup_verify: `http://${server}/api/airtable/signup/verify/:token`,
-  signout: `http://${server}/api/airtable/signout/`,
-  isLoggedIn: `http://${server}/api/airtable/isLoggedIn/`,
-  getAccountInfo: `http://${server}/api/airtable/getInfo`,
-  updateAccount: `http://${server}/api/airtable/update`,
-  updatePassword: `http://${server}/api/airtable/update_password/`,
-  verifyUser: `http://${server}/api/reset/forgot`,
-  resetPassword: `http://${server}/api/reset/:token`,
-  application_status: `http://${server}/api/airtable/application_status`,
-  duplicateInfoCheck: `http://${server}/api/airtable/duplicateInfoCheck`,
+  login: `${server}/api/airtable/login/`,
+  signup: `${server}/api/airtable/signup/`,
+  email: `${server}/api/airtable/email/`,
+  signup_verify: `${server}/api/airtable/signup/verify/:token`,
+  signout: `${server}/api/airtable/signout/`,
+  isLoggedIn: `${server}/api/airtable/isLoggedIn/`,
+  getAccountInfo: `${server}/api/airtable/getInfo`,
+  updateAccount: `${server}/api/airtable/update`,
+  updatePassword: `${server}/api/airtable/update_password/`,
+  verifyUser: `${server}/api/reset/forgot`,
+  resetPassword: `${server}/api/reset/:token`,
+  application_status: `${server}/api/airtable/application_status`,
+  duplicateInfoCheck: `${server}/api/airtable/duplicateInfoCheck`,
 };
 


### PR DESCRIPTION
previously all routes would be called through http no matter what server you were using, now you dictate whether they should be requested over https or http in the server constant. This fixes the issue with the frontend not being able to connect to the back with ssl, requests were being blocked because the were http.